### PR TITLE
[WIP] Remove hardcoded jcstress result path. (#1)

### DIFF
--- a/src/main/scala/pl/project13/sbt/jcstress/JCStressPlugin.scala
+++ b/src/main/scala/pl/project13/sbt/jcstress/JCStressPlugin.scala
@@ -24,7 +24,8 @@ object JCStressPlugin extends sbt.AutoPlugin {
 
   override def projectSettings = Seq(
     version in Jcstress := "0.3",
-    
+    resultFolder := baseDirectory.value / "results",
+
     libraryDependencies += "org.openjdk.jcstress" % "jcstress-core" % (version in Jcstress).value % "test",
     libraryDependencies += "net.sf.jopt-simple"   % "jopt-simple"   % "4.6"   % "test",
 
@@ -87,12 +88,12 @@ object JCStressPlugin extends sbt.AutoPlugin {
         }
         
         log.info("Running tests...")
+        val resultDir = resultFolder.value.getAbsolutePath
         try {
-          val x = s"java -cp $javaClasspath org.openjdk.jcstress.Main ".!!(logIt)
+          val x = s"java -cp $javaClasspath org.openjdk.jcstress.Main -r $resultDir".!!(logIt)
           log.info(x)
         } finally {
-          val resultsIndex = baseDirectory.value / "results" / "index.html"
-          log.info(s"See results: $resultsIndex")
+          log.info(s"See results: $resultDir/index.html")
         }
       }
         .dependsOn(compile in Compile)
@@ -123,7 +124,8 @@ object JCStressPlugin extends sbt.AutoPlugin {
 
 
   object autoImport {
-    final val Jcstress = sbt.config("jcstress") extend sbt.Configurations.TestInternal  
+    final val Jcstress = sbt.config("jcstress") extend sbt.Configurations.TestInternal
+    val resultFolder = settingKey[File]("sbt-jcstress result folder")
   }
 
 }

--- a/src/sbt-test/sbt-jcstress/sample/.gitignore
+++ b/src/sbt-test/sbt-jcstress/sample/.gitignore
@@ -1,2 +1,4 @@
 results
+jcstress-results
 *.bin.gz
+

--- a/src/sbt-test/sbt-jcstress/sample/build.sbt
+++ b/src/sbt-test/sbt-jcstress/sample/build.sbt
@@ -1,3 +1,5 @@
 enablePlugins(JCStressPlugin)
 
 scalaVersion := "2.12.1"
+
+resultFolder := baseDirectory.value / "jcstress-results"


### PR DESCRIPTION
Fix #1 .

Users could add this line to `build.sbt`.
```sbt
resultFolder := baseDirectory.value / "jcstress-results"
```
I kept original type `File`. Basically, users could export results to anywhere not only the base directory.

BTW, I am thinking about may we follow the style of `sbt-jmh`. I mean [this piece of `sbt-jmh`](https://github.com/ktoso/sbt-jmh/blob/v0.2.27/plugin/src/main/scala/pl/project13/scala/sbt/JmhPlugin.scala#L15-L23). I know this is not a big deal, I just found the difference. Thanks! :)

